### PR TITLE
修复当有遮罩层嵌套操作时的异常现象

### DIFF
--- a/js/hui.js
+++ b/js/hui.js
@@ -563,7 +563,7 @@ var hui = (function(selector){
 			document.body.appendChild(_hui.mask);
 		}
 	};
-	_hui.maskHide = function(){if(_hui.mask){document.body.removeChild(_hui.mask);}}
+	_hui.maskHide = function(){_hui.mask=document.getElementById('hui-mask');if(_hui.mask){document.body.removeChild(_hui.mask);}}
 	_hui.maskTap  = function(callBack){_hui.mask.addEventListener('click', callBack);}
 	_hui.dialogBase  = function(){
 		hui.dialogDom = document.getElementById('hui-dialog');

--- a/js/hui.js
+++ b/js/hui.js
@@ -555,7 +555,9 @@ var hui = (function(selector){
 		_hui.ToastTimer = setTimeout(function(){toast.remove();}, 2500);
 	};
 	/* dialog */
+	var mask_count = 0;
 	_hui.maskShow = function(){
+		mask_count += 1;
 		_hui.mask = document.getElementById('hui-mask');
 		if(!_hui.mask){
 			_hui.mask = document.createElement('div');
@@ -563,7 +565,15 @@ var hui = (function(selector){
 			document.body.appendChild(_hui.mask);
 		}
 	};
-	_hui.maskHide = function(){_hui.mask=document.getElementById('hui-mask');if(_hui.mask){document.body.removeChild(_hui.mask);}}
+	_hui.maskHide = function(){
+		mask_count -= 1;
+		if (mask_count === 0){
+			_hui.mask = document.getElementById('hui-mask');
+			if(_hui.mask){
+				document.body.removeChild(_hui.mask);
+			}
+		}
+	};
 	_hui.maskTap  = function(callBack){_hui.mask.addEventListener('click', callBack);}
 	_hui.dialogBase  = function(){
 		hui.dialogDom = document.getElementById('hui-dialog');


### PR DESCRIPTION
现象：执行以下代码时就会报错
原因：遮罩层被重复操作
修复：通过增加计数器来避免异常现象
`<!DOCTYPE html>
<html>
<head>
<meta charset="utf-8">
<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
<title>HUI </title>
<link rel="stylesheet" type="text/css" href="../css/hui.css" />
</head>
<body>
<header class="hui-header">
    <div id="hui-back"></div>
    <h1>HUI </h1>
    <div id="hui-header-menu"></div>
</header>
<div class="hui-wrap">
    <div class="hui-center-title" style="margin-top:15px;"><h1>演示样例</h1></div>
    <div style="padding:28px; text-align:center;" class="hui-text">
        点击右上角的菜单按钮来体验效果吧！
    </div>
</div>
<script type="text/javascript" src="../js/hui.js"></script>
<script type="text/javascript">
var meuns = ['我的订单', '我的消息', '我的收藏', '退出登录'];
var cancel = '关闭菜单';
hui('#hui-header-menu').click(function(){
    hui.actionSheet(meuns, cancel, function(e){
        console.log(e.index);
        hui.toast(e.innerHTML);
        hui.alert('警告信息！','好的', function(){console.log('ok');})
    });
});
</script>
</body>
</html>`